### PR TITLE
Preserve hardlinks when recreating config/plugin folders

### DIFF
--- a/container/engine/includes/0-functions.sh
+++ b/container/engine/includes/0-functions.sh
@@ -255,7 +255,7 @@ function downloadAndInstallTsModsForWorld(){
                 unzip -o $tsModsDir/$modFileConstructed BepInExPack_Valheim/* -d /tmp/BepInEx_tmp/ > /dev/null 2>&1
                 RESULT=$?
                 if [ $RESULT = 0 ]; then
-                        cp -prfv /tmp/BepInEx_tmp/BepInExPack_Valheim/* $worldsDirectoryRoot/$worldName/game/. > /dev/null 2>&1
+                        cp -arfv /tmp/BepInEx_tmp/BepInExPack_Valheim/* $worldsDirectoryRoot/$worldName/game/. > /dev/null 2>&1
                         rm -rf /tmp/BepInEx_tmp
                 fi
 
@@ -269,7 +269,7 @@ function downloadAndInstallTsModsForWorld(){
                 rm -rf /tmp/BepInEx_tmp
                 mkdir /tmp/BepInEx_tmp
 		unzip -o $tsModsDir/$modFileConstructed config/* -d /tmp/BepInEx_tmp/ > /dev/null 2>&1
-		cp -prfv /tmp/BepInEx_tmp/config/* $worldsDirectoryRoot/$worldName/game/BepInEx/config/. > /dev/null 2>&1
+		cp -arfv /tmp/BepInEx_tmp/config/* $worldsDirectoryRoot/$worldName/game/BepInEx/config/. > /dev/null 2>&1
 
 		#Patchers
 		unzip -j -o $tsModsDir/$modFileConstructed patchers/* -d $worldsDirectoryRoot/$worldName/game/BepInEx/patchers/$modName/ > /dev/null 2>&1
@@ -343,9 +343,9 @@ function installCustomModsConfigsPatchers() {
                 mkdir -p $customPatchersSourceDir
         fi
 
-	cp -prf $customModsSourceDir/* $worldModsDestDir/. > /dev/null 2>&1
-	cp -prf $customConfigsSourceDir/* $worldConfigsDestDir/. > /dev/null 2>&1
-	cp -prf $customPatchersSourceDir/* $worldPatchersDestDir/. > /dev/null 2>&1
+	cp -arf $customModsSourceDir/* $worldModsDestDir/. > /dev/null 2>&1
+	cp -arf $customConfigsSourceDir/* $worldConfigsDestDir/. > /dev/null 2>&1
+	cp -arf $customPatchersSourceDir/* $worldPatchersDestDir/. > /dev/null 2>&1
 
 	chown -R phvalheim:phvalheim $customModsSourceDir
 	chown -R phvalheim:phvalheim $customConfigsSourceDir
@@ -367,7 +367,7 @@ function InstallCustomConfigSecureFiles() {
                 mkdir -p $customConfigsSecureSourceDir
         fi
 
-	cp -prf $customConfigsSecureSourceDir/* $worldConfigsDestDir/. > /dev/null 2>&1
+	cp -arf $customConfigsSecureSourceDir/* $worldConfigsDestDir/. > /dev/null 2>&1
 
 	chown -R phvalheim:phvalheim $customConfigsSecureSourceDir
 }

--- a/container/engine/tools/logRotater.sh
+++ b/container/engine/tools/logRotater.sh
@@ -12,7 +12,7 @@ for logFile in $logFiles; do
 
 	if [ $logSize -gt $maxLogSize ]; then
 		echo "`date` [NOTICE : logrotater] Rotating logs for $logFile... "
-		cp -prfv $logFile $logFile.1  > /dev/null 2>&1
+		cp -arfv $logFile $logFile.1  > /dev/null 2>&1
 		echo "" > $logFile 
 	fi
 done

--- a/container/games/valheim/scripts/importWorld.sh
+++ b/container/games/valheim/scripts/importWorld.sh
@@ -126,10 +126,10 @@ cp $worldDir/$worldName.db /opt/stateful/games/valheim/worlds/$worldName/game/.c
 cp $worldDir/$worldName.fwl /opt/stateful/games/valheim/worlds/$worldName/game/.config/unity3d/IronGate/Valheim/worlds_local/.
 
 # add imported mods: you shouldn't do this. you should use PhValheim's mod manager which will keep plugins up-to-date. using the custom_plugins directory is acceptable if the mod(s) are not in thunderstore.
-#cp -prfv import_wip/BepInEx/plugins/* /opt/stateful/games/valheim/worlds/$worldName/custom_plugins/.
+#cp -arfv import_wip/BepInEx/plugins/* /opt/stateful/games/valheim/worlds/$worldName/custom_plugins/.
 
 # add imported configs
-cp -prfv import_wip/BepInEx/config/* /opt/stateful/games/valheim/worlds/$worldName/custom_configs/.
+cp -arfv import_wip/BepInEx/config/* /opt/stateful/games/valheim/worlds/$worldName/custom_configs/.
 if [ -f "/opt/stateful/games/valheim/worlds/$worldName/custom_configs/BepInEx.cfg" ]; then
 	rm /opt/stateful/games/valheim/worlds/$worldName/custom_configs/BepInEx.cfg
 fi
@@ -138,7 +138,7 @@ if [ -f "/opt/stateful/games/valheim/worlds/$worldName/custom_configs/quick_conn
 fi
 
 # add imported patchers: you shouldn't do this. you should use PhValheim's mod manager which will keep plugins up-to-date. using the custom_plugins directory is acceptable if the mod(s) are not in thunderstore.
-#cp -prfv import_wip/BepInEx/plugins/* /opt/stateful/games/valheim/worlds/$worldName/custom_patchers/.
+#cp -arfv import_wip/BepInEx/plugins/* /opt/stateful/games/valheim/worlds/$worldName/custom_patchers/.
 
 # set admins
 echo "// List admin players ID  ONE per line" > /opt/stateful/games/valheim/worlds/$worldName/game/.config/unity3d/IronGate/Valheim/adminlist.txt


### PR DESCRIPTION
Hi, I've found this issue when I was configuring some plugins like [DiscordConnector](https://valheim.thunderstore.io/package/nwesterhausen/DiscordConnector/) and [WebMap](https://github.com/msuddaby/ValheimWebMap). These mods create persistent files that aren't preserved when Updating the Valheim setup or when installing new mods. (I asked about these issues in the Discord beforehand, same handle as here)

I tried to solve this by creating hardlinks to the newly created files inside the custom_config[_secure] and custom_plugins folders. The issue is, it works for the first time until the first reset. The container copies the files inside the custom folders, **without preserving the hardlinks**. This serves only as a "backup" until the next reset. I have to recreate the hardlinks each time I update the server.

I suggest this change, but I'm not UNIX-savvy and I don't know if it would create other issues when copying with -a instead of -p. Feel free to suggest any changes.