### PR TITLE
Make the servers with no citizens available in the public authorized page

### DIFF
--- a/container/nginx/www/admin/citizensEditor.php
+++ b/container/nginx/www/admin/citizensEditor.php
@@ -23,6 +23,12 @@ if (isset($_GET['citizens'],$_GET['world']))
 {
 	$citizens = $_GET['citizens'];
 	$world = $_GET['world'];
+	$public = $_GET['public'];
+
+	if($public)
+	{
+		$citizens = "";
+	}
 
 	# trim and clean up new input, we don't store carriage returns in the database
 	$citizens = str_replace("\r\n", " ", $citizens);
@@ -65,7 +71,6 @@ $currentAllowListFile = file_get_contents("/opt/stateful/games/valheim/worlds/$w
 	<body>
 
 		<p class='pri-color' style='margin-top: 1%;' align='center'><label class='alt-color'>Note:</label> <i><b>Only</b> listed SteamIDs will be able to join this world.</i></p>
-		<p class='pri-color' style='margin-top: -0.7%;font-size: 14px;' align='center'><label class='alt-color'>Note:</label> <i>If left empty, anyone can join.</i></p>
 		<form action='citizensEditor.php'>
 			<table style="margin-top: 45px;" align='center' border='0' class='outline'>
 
@@ -91,6 +96,16 @@ $currentAllowListFile = file_get_contents("/opt/stateful/games/valheim/worlds/$w
 					</th>
 					<td>
 						<textarea class='disabled outline textarea' style='resize: none;' cols='40' rows='20' name='citizens' disabled><?php print $currentAllowListFile;?></textarea>
+					</td>
+				</tr>
+
+				<tr>
+					<td align='center' style='text-align: center;' colspan='2'>
+						<table align='center' style='text-align: center;' border=0>
+							<td align='center' style='text-align: center;'>
+								<input type="checkbox" name="public" value="public" <?php echo (empty($currentCitizens) ? 'checked' : '');?>>
+								<label for="public"> Make world public</lable>
+						</table>
 					</td>
 				</tr>
 

--- a/container/nginx/www/includes/db_gets.php
+++ b/container/nginx/www/includes/db_gets.php
@@ -139,11 +139,10 @@ function getSeed($pdo,$world) {
 }
 
 function getMyWorlds($pdo,$citizen) {
-        $sth = $pdo->query("SELECT name FROM worlds WHERE citizens LIKE '%$citizen%' ORDER BY currentMemory, name ASC");
+        $sth = $pdo->query("SELECT name FROM worlds WHERE citizens LIKE '%$citizen%' OR citizens LIKE  '' ORDER BY currentMemory, name ASC");
         $result = $sth->fetchAll(PDO::FETCH_COLUMN);
         return $result;
 }
-
 
 function getMD5($pdo,$world) {
         $sth = $pdo->prepare("SELECT world_md5 FROM worlds WHERE name='$world'");

--- a/container/nginx/www/includes/db_sets.php
+++ b/container/nginx/www/includes/db_sets.php
@@ -12,7 +12,7 @@ function addWorld($pdo,$new_world,$external_endpoint,$seed){
 		$result = $row['name'] ?? 'placeholder';
 	
 		if (strcmp($new_world, $result) !== 0){
-		 	$update = $pdo->exec( "INSERT INTO worlds (mode,status,name,external_endpoint,seed) VALUES ('create','Down','$new_world','$external_endpoint','$seed') ");
+		 	$update = $pdo->exec( "INSERT INTO worlds (mode,status,name,external_endpoint,seed,citizens) VALUES ('create','Down','$new_world','$external_endpoint','$seed','') ");
 			return 0;			
 		} else {
 			return 2;


### PR DESCRIPTION
As the edit citizen page states that anyone should be able to join if left empty, one would expect the public authorized page to show these worlds.

resolves #5
resolves #26